### PR TITLE
Clean up Game List and leaving games

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -72,7 +72,6 @@ class App extends Component {
       socket.emit('getActiveUsers');
     });
     socket.on('recieveActiveUsers', users => {
-      // console.log(`-------\n\nusers returned are:`, users);
       this.setState({activeUsers: users})
     });
     // This will be emitted by the server when a user creates a new game,
@@ -82,9 +81,6 @@ class App extends Component {
       let games = {...this.state.games};
       games[game._id] = game;
       this.setState({ games });
-      // if (game.playerOrder[0] === this.state.user.id) {
-      //   // redirectToPath(`/game/${game._id}`);
-      // }
     });
     socket.on('games', newGames => {
       let games = {...this.state.games};
@@ -93,9 +89,6 @@ class App extends Component {
         socket.emit('myHand', newGames[g]._id);
       }
       this.setState({ games });
-      // const myGames = games.filter(game => {
-      //   return game.playerOrder.some(id => id === this.state.user.id);
-      // });
     });
 
     let getPlayerName = playerId => {
@@ -125,9 +118,12 @@ class App extends Component {
     socket.on('gameStateUpdate', updateGameInState({ refresh: true }));
     socket.on('gameStarted', updateGameInState({ refresh: true }));
     socket.on('partialState', updateGameInState({ refresh: false }));
-    socket.on('leftGame', game => {
-      console.log('finished leaving game.');
-      redirectToPath(`/main`);
+    socket.on('leftGame', () => redirectToPath(`/main`));
+    socket.on('updateGameList', gameId => {
+      console.log('a user abandoned a game, so update game list');
+      let games = {...this.state.games};
+      delete games[gameId];
+      this.setState({ games });
     });
     socket.on('err', err => {console.log(err)});
   }

--- a/client/src/pages/GameView/GameView.js
+++ b/client/src/pages/GameView/GameView.js
@@ -155,7 +155,9 @@ class GameView extends Component {
             />
             {/* <GameChat /> */}
           <button className="green" onClick={this.sendMove}>Play Card</button>
-          <button  className="green" onClick={this.startGame}>Start Game</button>
+          <button onClick={
+            game => this.socket.emit('leaveGame', this.props.gameId)
+          }>Abandon Game</button>
         </div>
       </div>
 

--- a/client/src/pages/MainPage/MainPage.js
+++ b/client/src/pages/MainPage/MainPage.js
@@ -69,7 +69,7 @@ class MainPage extends Component {
   }
 
 renderGame(game) {
-   const canJoinGame = game.open;
+   const canJoinGame = game.open || game.playerOrder.some(id => id === this.props.user.id);
    return (
      <div className="gameListEntry" key={game._id}>
        <div>

--- a/controllers/game.js
+++ b/controllers/game.js
@@ -63,12 +63,12 @@ module.exports = {
     });
   },
   leaveGame: (_id, userID) => {
+    console.log(userID, 'leaving', _id);
     return new Promise((resolve, reject) => {
       db.Game.findById(_id)
         .then(game => {
           if (!game)
             return reject('Game not found.');
-          console.log(userID, 'leaving', _id);
           // if (!game.open)
           //   return reject('Cannot leave game in progress.');
           if (game.playerOrder.indexOf(userID) < 0)

--- a/routes/socket/game.js
+++ b/routes/socket/game.js
@@ -4,8 +4,8 @@ const User = require('../../controllers/user');
 const chalk = require('chalk');
 
 module.exports = (socket, io, userSockets) => {
-  console.log(`${chalk.underline.green(`socket.io`)}: listening for connection`);
-    console.log(`${chalk.underline.green(`socket.io`)}: connection created`);
+  // console.log(`${chalk.underline.green(`socket.io`)}: listening for connection`);
+  //   console.log(`${chalk.underline.green(`socket.io`)}: connection created`);
 
     /*
     * Game logic
@@ -110,6 +110,7 @@ module.exports = (socket, io, userSockets) => {
         return socket.emit('err', { message: 'Not authenticated' });
       Game.leaveGame(gameID, socket.request.session.userId);
       socket.emit('leftGame');
+      io.emit('updateGameList', gameID);
       socket.leave(gameID); // Unsubscribe the user to this game's events
     });
 


### PR DESCRIPTION
Replace start game button with abandon game button during game play on game view. Add join button to all games that current user has joined if they are in the lobby, so they can switch between games and come back to them later. When a user abandons a game, update all other user game lists to be accurate.